### PR TITLE
feat: add water evaluation functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,6 +151,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "lexical-core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-util"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +299,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stm32"
 version = "0.1.0"
 dependencies = [
@@ -268,6 +314,7 @@ dependencies = [
  "hd44780-driver",
  "keypad",
  "keypad2",
+ "lexical-core",
  "libm",
  "no-std-compat",
  "panic-halt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,11 @@ keypad2 = "0.1.1"
 keypad = "0.2.2"
 no-std-compat = {version="0.4.1", features=["alloc"]}
 
+[dependencies.lexical-core]
+version = "0.8.5"
+default-features = false
+features = ["parse-floats"]
+
 [dependencies.stm32f4xx-hal]
 features = ["stm32f401", "rt"]
 version = "^0.13.2"

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,184 @@
+use embedded_hal::digital::v2::InputPin;
+use hd44780_driver::{bus::FourBitBus, Cursor, CursorBlink, Display, DisplayMode, HD44780};
+use keypad2::Keypad;
+use stm32f4xx_hal::{
+    gpio::{
+        gpioa::{PA10, PA2, PA3},
+        gpiob::{PB10, PB3, PB4, PB5},
+        Input, OpenDrain, Output, Pin, Pull,
+    },
+    pac::{self, TIM1},
+    prelude::*,
+    timer::Delay,
+};
+mod calcs;
+
+const MAX_DISPLAY_CHARS: usize = 16;
+
+pub type GenericKeypad = Keypad<
+    Pin<'A', 2>,
+    Pin<'B', 10>,
+    Pin<'B', 4>,
+    Pin<'B', 3>,
+    Pin<'A', 10, Output<OpenDrain>>,
+    Pin<'A', 3, Output<OpenDrain>>,
+    Pin<'B', 5, Output<OpenDrain>>,
+>;
+
+pub type GenericDelay = Delay<TIM1, 1000000>;
+
+pub type GenericDisplay = HD44780<
+    FourBitBus<
+        Pin<'C', 7, Output>,
+        Pin<'B', 6, Output>,
+        Pin<'A', 7, Output>,
+        Pin<'A', 6, Output>,
+        Pin<'A', 8, Output>,
+        Pin<'B', 0, Output>,
+    >,
+>;
+
+pub struct WaterData {
+    ph: f64,
+    cond: f64,
+    hardness: f64,
+}
+
+impl WaterData {
+    pub fn new() -> WaterData {
+        WaterData {
+            ph: 0.0,
+            cond: 0.0,
+            hardness: 0.0,
+        }
+    }
+}
+
+fn print_main_menu(lcd: &mut GenericDisplay, delay: &mut GenericDelay) {
+    write_screen("1. New data", "2. Summary (x)", lcd, delay);
+}
+
+fn add_data(
+    keypad: &mut GenericKeypad,
+    lcd: &mut GenericDisplay,
+    delay: &mut GenericDelay,
+) -> WaterData {
+    let mut ph = 0.0;
+    let mut cond = 0.0;
+    let mut hard = 0.0;
+
+    let prompts = [
+        ("pH:", &mut ph),
+        ("Conduc. (mS/cm):", &mut cond),
+        ("Hardness (mg/L):", &mut hard),
+    ];
+
+    for (text, var) in prompts {
+        lcd.reset(delay).unwrap();
+        lcd.clear(delay).unwrap();
+        write_line(text, false, lcd, delay);
+        shift_line(false, lcd, delay);
+
+        let mut input = ['\0'; MAX_DISPLAY_CHARS];
+        read_line(&mut input, keypad, delay);
+
+        let mut char_buffer = [0; MAX_DISPLAY_CHARS * 4];
+        for (i, c) in input.iter().enumerate() {
+            // this probably works?? i hope
+            // we might get more zeros than i'd hoped
+            c.encode_utf8(&mut char_buffer[i * 4..i * 4 + 4]);
+        }
+        *var = lexical_core::parse::<f64>(&char_buffer).unwrap();
+    }
+
+    // presentation screen 1
+    let ph_status = calcs::eval_ph(ph);
+    let hard_status = calcs::eval_hardness(hard);
+    let cond_status = calcs::eval_cond(cond);
+
+    WaterData {
+        ph: ph,
+        cond: cond,
+        hardness: hard,
+    }
+}
+
+fn read_char(keypad: &mut GenericKeypad, delay: &mut GenericDelay) -> char {
+    delay.delay_ms(1_u16);
+
+    loop {
+        let key = keypad.read_char(delay);
+
+        if key != ' ' {
+            if key == '#' {
+                // treat as enter
+                return ' ';
+            } else if key == '*' {
+                return '.';
+            } else {
+                // number
+                return key;
+            }
+        }
+        delay.delay_ms(10u16);
+    }
+}
+
+fn read_line(
+    string: &mut [char; MAX_DISPLAY_CHARS],
+    keypad: &mut GenericKeypad,
+    delay: &mut GenericDelay,
+) {
+    // TODO: display text on screen on input
+    delay.delay_ms(1_u16);
+    let mut index = 0;
+    loop {
+        let key = keypad.read_char(delay);
+
+        if key != ' ' {
+            let mut char = '.';
+            if key == '#' {
+                // treat as enter
+                break;
+            } else if key == '*' {
+                // decimal point
+                char = '.';
+            } else {
+                // number
+                char = key;
+            }
+
+            // make sure we don't overflow display
+            if index != MAX_DISPLAY_CHARS {
+                string[index] = char;
+                index += 1;
+            }
+        }
+        delay.delay_ms(10u16);
+    }
+    for i in index..MAX_DISPLAY_CHARS {
+        string[i] = '\0';
+    }
+}
+
+fn write_screen(first: &str, second: &str, lcd: &mut GenericDisplay, delay: &mut GenericDelay) {
+    delay.delay_ms(10u16);
+    lcd.clear(delay).unwrap();
+    lcd.reset(delay).unwrap();
+    lcd.write_str(first, delay).unwrap();
+    lcd.set_cursor_pos(40u8, delay).unwrap();
+    lcd.write_str(second, delay).unwrap();
+}
+
+fn write_line(string: &str, second_line: bool, lcd: &mut GenericDisplay, delay: &mut GenericDelay) {
+    delay.delay_ms(10u16);
+
+    let pos = if second_line { 40u8 } else { 0u8 };
+    lcd.set_cursor_pos(pos, delay).unwrap();
+    lcd.write_str(string, delay).unwrap(); // hope it also clears the rest of the line
+}
+
+fn shift_line(first_line: bool, lcd: &mut GenericDisplay, delay: &mut GenericDelay) {
+    let pos: u8 = if first_line { 0 } else { 40 };
+    lcd.set_cursor_pos(pos, delay).unwrap();
+}

--- a/src/types/calcs.rs
+++ b/src/types/calcs.rs
@@ -1,0 +1,101 @@
+use libm;
+
+pub enum QualityLevel {
+    Poor,
+    Ok,
+    Good,
+}
+
+pub enum Suggestion {
+    Remove(f64),
+    Add(f64),
+    None,
+}
+
+// HARDNESS:
+// 0-60: BAD
+// 60-80: OKAY
+// 80-100: GOOD
+// 100-150: OKAY
+// 150+: BAD
+
+pub fn eval_hardness(hardness: f64) -> QualityLevel {
+    if hardness > 150.0 || hardness < 60.0 {
+        QualityLevel::Poor
+    } else if hardness > 100.0 || hardness < 80.0 {
+        QualityLevel::Ok
+    } else {
+        QualityLevel::Good
+    }
+}
+
+pub fn improve_hardness(hardness: f64) -> Suggestion {
+    match hardness {
+        h if h > 100.0 => Suggestion::Remove(hardness - 100.0),
+        h if h < 80.0 => Suggestion::Add(80.0 - hardness),
+        _ => Suggestion::None,
+    }
+}
+
+// pH:
+// 0-6.5: BAD
+// 6.5-6: OKAY
+// 6-8: GOOD
+// 8-8.5: OKAY
+// 8.5+: BAD
+
+pub fn eval_ph(ph: f64) -> QualityLevel {
+    if ph > 8.5 || ph < 6.5 {
+        QualityLevel::Poor
+    } else if ph > 8.0 || ph < 6.0 {
+        QualityLevel::Ok
+    } else {
+        QualityLevel::Good
+    }
+}
+
+pub fn improve_ph(ph: f64) -> Suggestion {
+    // returns whether to add or remove BASE
+    let h_conc = libm::pow(10.0, -ph);
+    let ph_6_conc = 1e-6;
+    let ph_8_conc = 1e-8;
+
+    match h_conc {
+        h if h > ph_8_conc => Suggestion::Add(h - ph_8_conc),
+        h if h < ph_6_conc => Suggestion::Remove(ph_6_conc - h),
+        _ => Suggestion::None,
+    }
+}
+
+// COND:
+// 0-10: BAD
+// 10-50: OKAY
+// 50-120: GOOD
+// 120-180: OKAY
+// 180+: BAD
+
+pub fn eval_cond(cond: f64) -> QualityLevel {
+    // in units of mg/L
+    let salinity = (0.7317 * cond - 3.7635) * 0.55;
+    if salinity > 180.0 || salinity < 10.0 {
+        QualityLevel::Poor
+    } else if salinity > 120.0 || salinity < 50.0 {
+        QualityLevel::Ok
+    } else {
+        QualityLevel::Good
+    }
+}
+
+pub fn improve_cond(cond: f64) -> Suggestion {
+    // returns whether to add or remove total
+    // dissolved salts (TDS)
+
+    // in units of mg/L
+    let salinity = (0.7317 * cond - 3.7635) * 0.55;
+
+    match salinity {
+        s if s > 120.0 => Suggestion::Remove(s - 120.0),
+        s if s < 50.0 => Suggestion::Add(50.0 - s),
+        _ => Suggestion::None,
+    }
+}


### PR DESCRIPTION
Allow `main` to call specific functions `eval_{ph, cond, hardness}` and `improve_{ph, cond, hardness}` to handle processing behind the scenes.

## Feature changes

- Add the  main menu in `print_main_menu()`
- Create an initial implementation of `add_data()` to add new data points to be processed
- add evaluation and improvement functions as mentioned previously
- code refactor