### PR TITLE
feat: add memory allocation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,6 +168,7 @@ checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
 dependencies = [
  "lexical-parse-float",
  "lexical-util",
+ "lexical-write-float",
 ]
 
 [[package]]
@@ -197,6 +198,27 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
 dependencies = [
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
+dependencies = [
+ "lexical-util",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 3
 
 [[package]]
+name = "alloc-cortex-m"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b309e7a89884824cb3c8e5f882024269c95e90b2f746344f2914423ac33c452"
+dependencies = [
+ "cortex-m",
+ "linked_list_allocator",
+]
+
+[[package]]
 name = "bare-metal"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +213,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
+name = "linked_list_allocator"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e322f259d225fbae43a1b053b2dc6a5968a6bdf8b205f5de684dab485b95030e"
+
+[[package]]
 name = "nb"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,6 +324,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "stm32"
 version = "0.1.0"
 dependencies = [
+ "alloc-cortex-m",
  "cortex-m",
  "cortex-m-rt",
  "embedded-hal 0.2.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ no-std-compat = {version="0.4.1", features=["alloc"]}
 [dependencies.lexical-core]
 version = "0.8.5"
 default-features = false
-features = ["parse-floats"]
+features = ["parse-floats", "write-floats"]
 
 [dependencies.stm32f4xx-hal]
 features = ["stm32f401", "rt"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 cortex-m = "^0.7.6"
 cortex-m-rt = "^0.7.1"
+alloc-cortex-m = "0.4.3"
 panic-halt = "^0.2.0"
 libm = "0.2.5"
 embedded-hal = "0.2.7"

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,6 +135,7 @@ fn main() -> ! {
         }
         if index < 5 {
             data_points[index] = add_data(&mut keypad, &mut lcd, &mut delay);
+            index += 1;
         } else {
             // run summary
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,7 +132,6 @@ fn main() -> ! {
         if c == '*' || c == '#' {
             continue;
         }
-        let c_int = c.to_digit(10).unwrap();
         add_data(&mut keypad, &mut lcd, &mut delay);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,7 @@ fn main() -> ! {
     ];
 
     #[allow(clippy::empty_loop)]
-    let index = 0;
+    let mut index = 0;
     loop {
         print_main_menu(index, &mut lcd, &mut delay);
         let c = read_char(&mut keypad, &mut delay);

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,7 +117,7 @@ fn main() -> ! {
 
     let mut led = gpioa.pa5.into_push_pull_output();
 
-    let data_points: [WaterData; 5] = [
+    let mut data_points: [WaterData; 5] = [
         WaterData::new(),
         WaterData::new(),
         WaterData::new(),
@@ -126,12 +126,17 @@ fn main() -> ! {
     ];
 
     #[allow(clippy::empty_loop)]
+    let index = 0;
     loop {
-        print_main_menu(&mut lcd, &mut delay);
+        print_main_menu(index, &mut lcd, &mut delay);
         let c = read_char(&mut keypad, &mut delay);
         if c == '*' || c == '#' {
             continue;
         }
-        add_data(&mut keypad, &mut lcd, &mut delay);
+        if index < 5 {
+            data_points[index] = add_data(&mut keypad, &mut lcd, &mut delay);
+        } else {
+            // run summary
+        }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -96,6 +96,9 @@ fn add_data(
     let hard_status = calcs::eval_hardness(hard);
     let cond_status = calcs::eval_cond(cond);
 
+    let first_line = "pH " + "2";
+    // i'm gonna cry you can actually allocate things
+
     WaterData {
         ph: ph,
         cond: cond,

--- a/src/types.rs
+++ b/src/types.rs
@@ -153,21 +153,21 @@ pub fn add_data(
         &str,
     ); 3] = [
         (
-            "pH:",
+            "pH",
             &|x: Suggestion| match x {
-                Suggestion::Add(a) => "add base OH-:",
-                Suggestion::Remove(a) => "remove base OH-:",
+                Suggestion::Add(a) => "add base:",
+                Suggestion::Remove(a) => "remove base:",
                 Suggestion::None => "Good",
             },
             &improve_ph,
             &ph,
-            "mg/L CaCO3",
+            "mol/L OH-",
         ),
         (
-            "Cond:",
+            "Cond",
             &|x: Suggestion| match x {
                 Suggestion::Add(a) => "add salt:",
-                Suggestion::Remove(a) => "remove salt:",
+                Suggestion::Remove(a) => "rem. salt:",
                 Suggestion::None => "Good",
             },
             &improve_cond,
@@ -175,15 +175,15 @@ pub fn add_data(
             "mg/L",
         ),
         (
-            "Ha:",
+            "Ha",
             &|x: Suggestion| match x {
                 Suggestion::Add(a) => "add CaCO3:",
-                Suggestion::Remove(a) => "remove CaCO3:",
+                Suggestion::Remove(a) => "rem. CaCO3:",
                 Suggestion::None => "Good",
             },
             &improve_hardness,
             &hard,
-            "mg/L",
+            "mg/L CaCO3",
         ),
     ];
 
@@ -198,9 +198,10 @@ pub fn add_data(
             Suggestion::Remove(x) => x.to_string(),
         };
 
-        let second_line = format!("{} {}", value, units);
+        let second_line = format!("{:.2} {}", value, units);
 
         write_screen(first_line.as_str(), second_line.as_str(), lcd, delay);
+        read_char(keypad, delay);
     }
 
     WaterData {
@@ -253,9 +254,12 @@ pub fn read_line(
 
         if key != ' ' {
             let mut char = '.';
-            if key == '#' {
+            if key == '#' && index > 0 {
                 // treat as enter
+                // do not accept blank input
                 break;
+            } else if key == '#' {
+                continue;
             } else if key == '*' {
                 // decimal point
                 char = '.';

--- a/src/types.rs
+++ b/src/types.rs
@@ -203,7 +203,11 @@ pub fn add_data(
             Suggestion::Remove(x) => x.to_string(),
         };
 
-        let second_line = format!("{:.2} {}", value, units);
+        let second_line = if suggestion != Suggestion::None {
+            format!("{:.2} {}", value, units)
+        } else {
+            String::new()
+        };
 
         write_screen(first_line.as_str(), second_line.as_str(), lcd, delay);
         read_char(keypad, delay);

--- a/src/types.rs
+++ b/src/types.rs
@@ -89,8 +89,13 @@ impl Stat {
     }
 }
 
-pub fn print_main_menu(lcd: &mut GenericDisplay, delay: &mut GenericDelay) {
-    write_screen("1. New data", "2. Summary (x)", lcd, delay);
+pub fn print_main_menu(num_entries: usize, lcd: &mut GenericDisplay, delay: &mut GenericDelay) {
+    write_screen(
+        "1. New data",
+        format!("2. Summary ({})", num_entries).as_str(),
+        lcd,
+        delay,
+    );
 }
 
 pub fn add_data(

--- a/src/types.rs
+++ b/src/types.rs
@@ -155,8 +155,8 @@ pub fn add_data(
         (
             "pH",
             &|x: Suggestion| match x {
-                Suggestion::Add(a) => "add base:",
-                Suggestion::Remove(a) => "remove base:",
+                Suggestion::Add(a) => "add base",
+                Suggestion::Remove(a) => "remove base",
                 Suggestion::None => "Good",
             },
             &improve_ph,
@@ -166,8 +166,8 @@ pub fn add_data(
         (
             "Cond",
             &|x: Suggestion| match x {
-                Suggestion::Add(a) => "add salt:",
-                Suggestion::Remove(a) => "rem. salt:",
+                Suggestion::Add(a) => "add salt",
+                Suggestion::Remove(a) => "rem. salt",
                 Suggestion::None => "Good",
             },
             &improve_cond,
@@ -177,8 +177,8 @@ pub fn add_data(
         (
             "Ha",
             &|x: Suggestion| match x {
-                Suggestion::Add(a) => "add CaCO3:",
-                Suggestion::Remove(a) => "rem. CaCO3:",
+                Suggestion::Add(a) => "add CaCO3",
+                Suggestion::Remove(a) => "rem. CaCO3",
                 Suggestion::None => "Good",
             },
             &improve_hardness,

--- a/src/types/calcs.rs
+++ b/src/types/calcs.rs
@@ -7,7 +7,7 @@ pub enum QualityLevel {
     Good,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq)]
 pub enum Suggestion {
     Remove(f64),
     Add(f64),

--- a/src/types/calcs.rs
+++ b/src/types/calcs.rs
@@ -7,6 +7,7 @@ pub enum QualityLevel {
     Good,
 }
 
+#[derive(Copy, Clone)]
 pub enum Suggestion {
     Remove(f64),
     Add(f64),

--- a/src/types/calcs.rs
+++ b/src/types/calcs.rs
@@ -1,5 +1,6 @@
-use libm;
+use libm::{self, sqrt};
 
+#[derive(PartialEq, Clone, Copy)]
 pub enum QualityLevel {
     Poor,
     Ok,
@@ -10,6 +11,16 @@ pub enum Suggestion {
     Remove(f64),
     Add(f64),
     None,
+}
+
+impl QualityLevel {
+    pub fn code(&self) -> &str {
+        match *self {
+            QualityLevel::Good => "OK",
+            QualityLevel::Ok => "ME",
+            QualityLevel::Poor => "XD",
+        }
+    }
 }
 
 // HARDNESS:


### PR DESCRIPTION
This allows the program to properly add new data and lets us use the stdlib!

## Feature changes

- BREAKING: enables the `alloc` crate
- adjusts the pinout layout
- creates a static memory allocator and initialises it
- adds a main menu in `main`
- creates a skeleton struct to initially aggregate stats in `Stat` and implements some helper functions for it (`Stat::new()`)
- switches `alloc`-less `add_data()` to use strings, allowing for longer parsing
- added improvement suggestions to the user in `add_data()`