### PR TITLE
feat: add summary screen

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,8 @@ use stm32f4xx_hal::{
     timer::Delay,
 };
 use types::{
-    add_data, print_main_menu, read_char, GenericDelay, GenericDisplay, GenericKeypad, WaterData,
+    add_data, print_main_menu, read_char, summary, GenericDelay, GenericDisplay, GenericKeypad,
+    WaterData,
 };
 
 // Connections:
@@ -117,13 +118,7 @@ fn main() -> ! {
 
     let mut led = gpioa.pa5.into_push_pull_output();
 
-    let mut data_points: [WaterData; 5] = [
-        WaterData::new(),
-        WaterData::new(),
-        WaterData::new(),
-        WaterData::new(),
-        WaterData::new(),
-    ];
+    let mut data_points: [WaterData; 3] = [WaterData::new(), WaterData::new(), WaterData::new()];
 
     #[allow(clippy::empty_loop)]
     let mut index = 0;
@@ -133,11 +128,11 @@ fn main() -> ! {
         if c == '*' || c == '#' {
             continue;
         }
-        if index < 5 {
+        if index < data_points.len() {
             data_points[index] = add_data(&mut keypad, &mut lcd, &mut delay);
             index += 1;
         } else {
-            // run summary
+            summary(&data_points, &mut keypad, &mut delay, &mut lcd);
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -262,7 +262,7 @@ pub fn summary(
         stdev_str.truncate(4);
         avg_str.truncate(4);
 
-        let second_line = format!("     {}, {}", avg_str, stdev_str);
+        let second_line = format!("     {:4}  {:4}", avg_str, stdev_str);
 
         write_screen(first_line.as_str(), second_line.as_str(), lcd, delay);
 

--- a/src/types/calcs.rs
+++ b/src/types/calcs.rs
@@ -57,9 +57,9 @@ pub fn improve_hardness(hardness: f64) -> Suggestion {
 // 8.5+: BAD
 
 pub fn eval_ph(ph: f64) -> QualityLevel {
-    if ph > 8.5 || ph < 6.5 {
+    if ph > 8.5 || ph < 6.0 {
         QualityLevel::Poor
-    } else if ph > 8.0 || ph < 6.0 {
+    } else if ph > 8.0 || ph < 6.5 {
         QualityLevel::Ok
     } else {
         QualityLevel::Good


### PR DESCRIPTION
This PR adds the second screen (the summary).

## Feature changes

- Reduced the number of data points before automatic summary to 3
- Summary screen added to aggregate statistics via the `Stat` struct and `summary` function
- calculation functions adjusted to make use of vectors thanks to enabling allocation in #5 